### PR TITLE
Adds support to open the related file Side by Side

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Please open new [Github issues](https://github.com/eamodio/vscode-find-related/i
 |`findrelated.autoPreview`|Specifies whether to automatically preview related files upon selection
 |`findrelated.ignoreExcludes`|Specifies whether to ignore file excludes when searching for related files
 |`findrelated.openPreview`|Specifies whether or not to open the related file in a preview tab
+|`findrelated.openSideBySide`|Specifies whether to open the related file to the side
 
 ## Extension API
 

--- a/package.json
+++ b/package.json
@@ -167,6 +167,11 @@
                     "default": false,
                     "description": "Specifies whether to automatically open the related file if there is only 1 result"
                 },
+                "findrelated.openSideBySide": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether to open the related file to the side"
+                },
                 "findrelated.autoPreview": {
                     "type": "boolean",
                     "default": true,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 'use strict';
 import { Arrays, Strings } from './system';
-import { commands, Disposable, TextDocument, TextDocumentShowOptions, TextEditor, Uri, window, workspace } from 'vscode';
+import { commands, Disposable, TextDocument, TextDocumentShowOptions, TextEditor, Uri, ViewColumn, window, workspace } from 'vscode';
 import { configuration, ExtensionKey, IConfig } from './configuration';
 import { Logger } from './logger';
 import { RelatedQuickPick } from './quickPicks';
@@ -51,6 +51,15 @@ function command(command: string, options: CommandOptions = {}): Function {
             options: options
         });
     };
+}
+
+function defaultViewColumn(activeTextEditor: TextEditor | undefined): ViewColumn {
+    let column: ViewColumn = (activeTextEditor && activeTextEditor.viewColumn) || ViewColumn.One;
+    const cfg = configuration.get<IConfig>();
+    if (cfg.openSideBySide) {
+        column = column === ViewColumn.Three ? ViewColumn.One : column + 1;
+    }
+    return column;
 }
 
 export class Commands extends Disposable {
@@ -117,7 +126,7 @@ export async function openEditor(uri: Uri, options?: TextDocumentShowOptions): P
         const defaults: TextDocumentShowOptions = {
             preserveFocus: false,
             preview: true,
-            viewColumn: (window.activeTextEditor && window.activeTextEditor.viewColumn) || 1
+            viewColumn: defaultViewColumn(window.activeTextEditor)
         };
 
         const document = await workspace.openTextDocument(uri);

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export interface IConfig {
     applyWorkspaceRulesets: string[];
     autoOpen: boolean;
     autoPreview: boolean;
+    openSideBySide: boolean;
     debug: boolean;
     ignoreExcludes: boolean;
     openPreview: boolean;


### PR DESCRIPTION
Hi,

This PR adds support to open the related file **Side by Side** (Closes #10 ).

The code changes where minimal. I added a new config `findrelated.openSideBySide` with its default value as `false`, so the behavior remains the same, unless the user changes its settings. 

Let me know if any updated needs to be made

Thanks